### PR TITLE
Updated the fallback for browsers that don't support CSS clip-path (e.g. IE11, Edge).

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,19 @@
 let _clipPathSupported = null
 
+function isBrowserIeOrEdge () {
+  return document.documentMode || /Edge\//.test(navigator.userAgent)
+}
+
 // Check if clip-path is supported. From http://stackoverflow.com/a/30041538.
 export function clipPathSupported () {
   if (_clipPathSupported != null) {
     return _clipPathSupported
   }
   if (typeof document === 'undefined') {
+    _clipPathSupported = false
+    return false
+  }
+  if (isBrowserIeOrEdge()) {
     _clipPathSupported = false
     return false
   }


### PR DESCRIPTION
This is a very basic solution to fix the icon toggle for Edge browsers. I updated the `clipPathSupported()` function to return false if the current browser is IE or Edge. In order to have stable browser detection, the `https://github.com/faisalman/ua-parser-js` package is used.  

Is this solution sufficient?

Closes #7 